### PR TITLE
Allow for keyboard navigation when multiple instances of component are on a page

### DIFF
--- a/src/SwitchSelector.stories.tsx
+++ b/src/SwitchSelector.stories.tsx
@@ -14,6 +14,14 @@ const Template: ComponentStory<typeof SwitchSelector> = (args) => (
     </div>
 );
 
+const MultiTemplate: ComponentStory<typeof SwitchSelector> = (args) => (
+    <div style={{width: 300, height: 30}}>
+        <SwitchSelector {...args} />
+        <input type="text"></input>
+        <SwitchSelector {...args} />
+    </div>
+);
+
 export const OneOption = Template.bind({});
 OneOption.args = {
     ...switchSelectorMocks,
@@ -36,4 +44,10 @@ export const Disabled = Template.bind({});
 Disabled.args = {
     ...switchSelectorMocks,
     disabled: true
+};
+
+export const TwoSwitches = MultiTemplate.bind({});
+TwoSwitches.args = {
+    ...switchSelectorMocks,
+    options: switchSelectorMocks.options.slice(0, 2)
 };

--- a/src/SwitchSelector.tsx
+++ b/src/SwitchSelector.tsx
@@ -19,7 +19,7 @@ const SwitchSelector: React.FC<SwitchSelectorProps> = (props) => {
     );
 
     const _componentId = (Math.floor(Math.random() * (10000 - 1 + 1)) + 1).toString();
-    const _groupName = `rss-${_componentId}`
+    const _groupName = `rss-${_componentId}`;
 
     const {
         border = 0,

--- a/src/SwitchSelector.tsx
+++ b/src/SwitchSelector.tsx
@@ -18,6 +18,9 @@ const SwitchSelector: React.FC<SwitchSelectorProps> = (props) => {
         canApplyInitialSelectedIndex ? initialSelectedIndex : 0
     );
 
+    const _componentId = (Math.floor(Math.random() * (10000 - 1 + 1)) + 1).toString();
+    const _groupName = `rss-${_componentId}`
+
     const {
         border = 0,
         backgroundColor = defaultColors.backgroundColor,
@@ -73,10 +76,12 @@ const SwitchSelector: React.FC<SwitchSelectorProps> = (props) => {
                         isRawText={isRawText}
                         disabled={disabled}
                         aria-disabled={disabled}
+                        htmlFor={_optionId}
                         {...(isRawText ? labelRawTextProps : {})}
                     >
                         <OptionInput
                             type="radio"
+                            name={_groupName}
                             id={_optionId}
                             onChange={(): void => handleOnClick(index)}
                             checked={selectedIndex === index}
@@ -91,6 +96,7 @@ const SwitchSelector: React.FC<SwitchSelectorProps> = (props) => {
     if (!options.length) return null;
     return (
         <SwitchSelectorWrapper
+            role="radiogroup"
             selectedIndex={selectedIndex}
             optionsAmount={options.length}
             className={`${CLASS_NAMES_PREFIX}-wrapper ${


### PR DESCRIPTION
Hey,

You made a great component. I found that when I used 2 or more on a page that tabbing to them and/or using my arrow keys would have unexpected behavior. After looking at the [aria spec for radio buttons](https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/examples/radio/radio-1/radio-1.html) I saw that you weren't setting the name attr on the inputs.

I also see that the id's on the inputs are shared across instances. I didn't address this in my change, but thought I should bring it up. And the labels are missing the htmlFor attrs.

Thanks for your work,
Mike